### PR TITLE
docs: add "About this site" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# jhgaylor.github.io
+
+## About this site
+
+This is Jake Gaylor's personal portfolio site — a static site built with [Eleventy](https://www.11ty.dev/) and deployed via GitHub Pages.
+
+### Site sections
+
+- **`index.html`** — Home page and landing experience
+- **`bio/`** — Personal background and biography
+- **`blog/`** — Writing and blog posts
+- **`projects.html`** — Portfolio of projects Jake has worked on
+- **`resume.html`** — Résumé generated from `resume.json`
+- **`venn.html`** — Interactive Venn diagram visualization
+
+---
+
 # Render the Site
 
 npx @11ty/eleventy --serve 


### PR DESCRIPTION
## Summary

- Adds a new `## About this site` section to `README.md`, placed after the H1 title
- Describes the site as Jake Gaylor's personal portfolio built with Eleventy and deployed via GitHub Pages
- Lists all six top-level sections (`index.html`, `bio/`, `blog/`, `projects.html`, `resume.html`, `venn.html`) with one-line descriptions

Closes #2

## Test plan

- [ ] README renders correctly on GitHub with proper headings and list formatting
- [ ] Section is under 200 words total
- [ ] All listed site sections match actual directories/files in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)