### PR TITLE
docs: consolidate local-dev instructions into a 'Local development' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ This is Jake Gaylor's personal portfolio site — a static site built with [Elev
 
 ---
 
-# Render the Site
+## Local development
 
-npx @11ty/eleventy --serve 
+### Run the site locally
 
-# Render an updated resume.html from resume.json
+Starts an Eleventy dev server with live reload:
 
-Update `resume.json` as needed.
+```
+npx @11ty/eleventy --serve
+```
 
-Run `npm run build-resume`
+### Rebuild the résumé
 
-Git commit all the changes to both files
+1. Update `resume.json` as needed.
+2. Run `npm run build-resume`
+3. Git commit all the changes to both files.


### PR DESCRIPTION
## Summary

- Replaces bare `# Render the Site` and `# Render an updated resume.html from resume.json` H1 fragments with a single `## Local development` section
- Adds `### Run the site locally` subsection with a one-line description and fenced code block for `npx @11ty/eleventy --serve`
- Adds `### Rebuild the résumé` subsection with the 3-step flow reformatted as a numbered list

No content removed — all existing commands and steps are preserved, just reorganized under a coherent section.

Closes #4

## Test plan

- [ ] README renders correctly on GitHub (headings, code block, numbered list)
- [ ] `## Local development` section appears between "About this site" and end of file
- [ ] Old H1 fragments (`# Render the Site`, `# Render an updated resume.html from resume.json`) are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)