### PR TITLE
Add Sveltia CMS admin panel

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -67,6 +67,8 @@ export default function(eleventyConfig) {
 
     eleventyConfig.addPassthroughCopy({ "resume.json": "./resume.json" });
 
+    eleventyConfig.addPassthroughCopy({ "admin": "admin" });
+
     eleventyConfig.addPairedShortcode("infobox", function(content) {
         return `<div class="info-box">${content}</div>`;
     });

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -8,8 +8,8 @@ backend:
   #   2. Set Homepage URL: https://jakegaylor.com
   #   3. Set Authorization callback URL: https://jakegaylor.com/admin/
   #   4. Copy the Client ID and paste it below, then uncomment both lines.
-  # auth_type: pkce
-  # app_id: YOUR_GITHUB_OAUTH_APP_CLIENT_ID
+  auth_type: pkce
+  app_id: Ov23liRFOk2dC67b3HFW
 
 site_url: https://jakegaylor.com
 media_folder: _assets/images

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,51 @@
+backend:
+  name: github
+  repo: jhgaylor/jhgaylor.github.io
+  branch: main
+  # Sveltia supports PKCE OAuth — no proxy server or Netlify needed.
+  # Setup steps:
+  #   1. Go to https://github.com/settings/applications/new
+  #   2. Set Homepage URL: https://jakegaylor.com
+  #   3. Set Authorization callback URL: https://jakegaylor.com/admin/
+  #   4. Copy the Client ID and paste it below, then uncomment both lines.
+  # auth_type: pkce
+  # app_id: YOUR_GITHUB_OAUTH_APP_CLIENT_ID
+
+site_url: https://jakegaylor.com
+media_folder: _assets/images
+public_folder: /images
+
+collections:
+  - name: posts
+    label: Blog Posts
+    label_singular: Blog Post
+    folder: blog/posts
+    create: true
+    slug: "{{slug}}"
+    preview_path: "/blog/posts/{{slug}}/"
+    fields:
+      - { label: Title, name: title, widget: string }
+      - label: Date
+        name: date
+        widget: datetime
+        format: "YYYY-MM-DD"
+        date_format: "YYYY-MM-DD"
+        time_format: false
+      - label: Tags
+        name: tags
+        widget: list
+        default: ["posts"]
+        hint: '"posts" must stay in this list for the post to appear on the blog index and RSS feed.'
+      - label: Description
+        name: description
+        widget: text
+        required: false
+        hint: Short excerpt shown in the blog listing.
+      - label: Exclude from Collections
+        name: eleventyExcludeFromCollections
+        widget: boolean
+        required: false
+        default: false
+        hint: Hides post from blog index and RSS feed without deleting it.
+      - { label: Layout, name: layout, widget: hidden, default: "layouts/blog.html" }
+      - { label: Body, name: body, widget: markdown }

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <title>Content Manager</title>
+</head>
+<body>
+  <script src="https://unpkg.com/sveltia-cms/dist/sveltia-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What this does

Adds a `/admin/` panel powered by [Sveltia CMS](https://github.com/sveltia/sveltia-cms) — a drop-in, actively-maintained alternative to Decap/Netlify CMS that works directly with the GitHub API. No Netlify account, no proxy server, no new CI steps.

Three changes:
- `admin/index.html` — loads Sveltia from CDN
- `admin/config.yml` — wires up the `blog/posts` collection with all existing front matter fields
- `.eleventy.js` — passes the `admin/` directory through to `_site/` so GitHub Pages serves it

## What you'd get

Visit `https://jakegaylor.com/admin/` to get a full WYSIWYG CMS:
- Create, edit, and publish blog posts from the browser
- Rich markdown editor with preview
- Tags field (with a hint that `posts` must stay in the list for the RSS feed)
- Optional description/excerpt field
- Toggle to exclude a post from the index without deleting it

Changes made through the CMS commit markdown files directly to `main`, which triggers the existing GitHub Actions deploy pipeline — nothing else changes.

## One setup step required before merging

Sveltia uses PKCE OAuth, which means **no server needed** — but you do need a GitHub OAuth App:

1. Go to https://github.com/settings/applications/new
2. Set **Homepage URL**: `https://jakegaylor.com`
3. Set **Authorization callback URL**: `https://jakegaylor.com/admin/`
4. Copy the **Client ID** and in `admin/config.yml`, uncomment and fill in:
   ```yaml
   auth_type: pkce
   app_id: YOUR_CLIENT_ID
   ```

That's it — no client secret is needed for PKCE.

## What's not included (intentionally)

- `resume.json` editing — the schema is complex enough that a raw JSON editor is worse than editing the file directly. Can be added later if wanted.
- Media uploads are wired to `_assets/images` → `/images/` (matching the existing passthrough copy), but images won't display in the editor preview until the OAuth App is set up.